### PR TITLE
update targetSdkLevel to 26

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="18"
-        android:targetSdkVersion="18" />
+        android:targetSdkVersion="26" />
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />


### PR DESCRIPTION
According to https://developer.android.com/distribute/best-practices/develop/target-sdk this will be required for any app updates from Nov 18 2018 onwards. Better start a bit earlier to avoid last-minute hectics.