### PR TITLE
Unconditional overwrite old AnonID

### DIFF
--- a/src/uk/ac/swansea/eduroamcat/WifiConfigAPI18.java
+++ b/src/uk/ac/swansea/eduroamcat/WifiConfigAPI18.java
@@ -154,7 +154,7 @@ public class WifiConfigAPI18 {
 	        if (enterpriseConfig.getPhase2Method()==Phase2.PAP) debug("Set to PAP OK");
 
 	        /*Anon ID*/
-	        if (aAuth.getAnonID().length()>0) enterpriseConfig.setAnonymousIdentity(aAuth.getAnonID());
+	        enterpriseConfig.setAnonymousIdentity(aAuth.getAnonID());
 	        debug("Set Anon to:"+aAuth.getAnonID());
 	        
 	        /*Cert*/


### PR DESCRIPTION
If someone loads a profile without an AnonID after
loading one with one, he will have the old (and now
most likely wrong) AnonID set in the active profile.

On Android 11 the only workaround is currently to delete
the WiFi Profile and install it anew, since you can't edit
it due to Domain not being set
